### PR TITLE
Add is_real_root

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
           {
             devShells.default = mkShell {
               nativeBuildInputs = [
+                bashInteractive
                 cargo-nextest
                 cargo-modules
                 cargo-nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub trait PathExt {
     /// - where `Path::parent()` returns `None`, `real_parent()` returns self for absolute root path, and appends `..` otherwise
     fn real_parent(&self) -> io::Result<PathBuf>;
 
-    /// Return whether this is a path to the root directory, regardless of whether or not it is relative.
+    /// Return whether this is a path to the root directory, regardless of whether or not it is relative or contains symlinks.
     /// Empty path is treated as `.`, that is, current directory, for compatibility with `Path::parent`.
     fn is_real_root(&self) -> io::Result<bool>;
 }

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -170,6 +170,22 @@ impl LinkFarm {
         self
     }
 
+    // create symlink to external path
+    pub fn symlink_external<P: AsRef<Path>, Q: AsRef<Path>>(
+        &mut self,
+        link: P,
+        original: Q,
+    ) -> &mut Self {
+        let link = self.tempdir.path().join(link);
+        if link.is_dir() {
+            symlink_dir(original, link).unwrap()
+        } else {
+            symlink_file(original, link).unwrap()
+        }
+
+        self
+    }
+
     pub fn strip_prefix<'a>(&self, path: &'a Path) -> &'a Path {
         path.strip_prefix(self.tempdir.path()).unwrap_or(path)
     }

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -183,6 +183,8 @@ impl LinkFarm {
             symlink_file(original, link).unwrap()
         }
 
+        self.contains_absolute_symlinks = true;
+
         self
     }
 

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -82,19 +82,15 @@ impl LinkFarm {
     // return how many levels below root is the top of the link farm
     pub fn depth_below_root(&self) -> usize {
         use Component::*;
-        let canonical_path = self.tempdir.path().canonicalize().unwrap();
-        let depth = canonical_path
+
+        // must canonicalize here because on MacOS tempdir contains a symlink
+        self.tempdir
+            .path()
+            .canonicalize()
+            .unwrap()
             .components()
             .filter(|c| matches!(c, Normal(_)))
-            .count();
-
-        println!(
-            "depth_below_root for {:?} with canonical {:?} is {}",
-            self.tempdir.path(),
-            canonical_path,
-            depth
-        );
-        depth
+            .count()
     }
 
     // return absolute path within link farm

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -79,6 +79,16 @@ impl LinkFarm {
         }
     }
 
+    // return how many levels below root is the top of the link farm
+    pub fn depth_below_root(&self) -> usize {
+        use Component::*;
+        self.tempdir
+            .path()
+            .components()
+            .filter(|c| matches!(c, Normal(_)))
+            .count()
+    }
+
     // return absolute path within link farm
     pub fn absolute<P>(&self, path: P) -> PathBuf
     where

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -82,11 +82,19 @@ impl LinkFarm {
     // return how many levels below root is the top of the link farm
     pub fn depth_below_root(&self) -> usize {
         use Component::*;
-        self.tempdir
+        let depth = self
+            .tempdir
             .path()
             .components()
             .filter(|c| matches!(c, Normal(_)))
-            .count()
+            .count();
+
+        println!(
+            "depth_below_root for {:?} is {}",
+            self.tempdir.path(),
+            depth
+        );
+        depth
     }
 
     // return absolute path within link farm

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -169,7 +169,7 @@ impl LinkFarm {
     }
 
     /// run the closure with the specified cwd
-    fn run_with_cwd<T, R, F, P>(&self, f: F, arg: T, cwd: P) -> R
+    fn run_without<T, R, F, P>(&self, f: F, arg: T, cwd: P) -> R
     where
         F: Fn(T) -> R,
         P: AsRef<Path>,
@@ -233,7 +233,7 @@ where
     let abs_path = farm.absolute(path);
     let abs_expected = farm.absolute(expected);
     let other_dir = tempdir().unwrap();
-    farm.run_with_cwd(
+    farm.run_without(
         |path| {
             let actual = path.real_parent();
             // if we ascended out of the farm rootdir it's not straightforward to verify the logical path
@@ -291,6 +291,7 @@ where
     let unc_path = convert_disk_to_unc(&abs_path);
     let unc_expected = convert_disk_to_unc(&abs_expected);
 
+    let other_dir = tempdir().unwrap();
     farm.run_without(
         |path| {
             let actual = path.real_parent();
@@ -309,6 +310,7 @@ where
             );
         },
         unc_path.as_path(),
+        other_dir,
     );
 }
 
@@ -404,7 +406,7 @@ where
     // test with absolute paths
     let abs_path = farm.absolute(path);
     let other_dir = tempdir().unwrap();
-    farm.run_with_cwd(
+    farm.run_without(
         |path| {
             let actual = path.is_real_root();
             is_expected_ok(abs_path.as_path(), actual, expected);
@@ -428,7 +430,7 @@ where
     let path: &Path = path.as_ref();
 
     // test with relative paths
-    farm.run_with_cwd(
+    farm.run_without(
         |path| {
             let actual = path.is_real_root();
             is_expected_ok(path, actual, expected);
@@ -445,12 +447,14 @@ where
 {
     let unc_path = convert_disk_to_unc(&abs_path);
 
+    let other_dir = tempdir().unwrap();
     farm.run_without(
         |path| {
             let actual = path.is_real_root();
             is_expected_ok(unc_path.as_path(), actual, expected);
         },
         unc_path.as_path(),
+        other_dir,
     );
 }
 

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -82,16 +82,16 @@ impl LinkFarm {
     // return how many levels below root is the top of the link farm
     pub fn depth_below_root(&self) -> usize {
         use Component::*;
-        let depth = self
-            .tempdir
-            .path()
+        let canonical_path = self.tempdir.path().canonicalize().unwrap();
+        let depth = canonical_path
             .components()
             .filter(|c| matches!(c, Normal(_)))
             .count();
 
         println!(
-            "depth_below_root for {:?} is {}",
+            "depth_below_root for {:?} with canonical {:?} is {}",
             self.tempdir.path(),
+            canonical_path,
             depth
         );
         depth

--- a/tests/path_ext.rs
+++ b/tests/path_ext.rs
@@ -257,6 +257,7 @@ fn test_is_real_root_not_files_directories(path: &str) {
 #[test_case("_B/."; "dot")]
 #[test_case("_B/.."; "dotdot")]
 #[test_case("_x1")]
+#[test_case("_B/b1")]
 #[cfg(not(target_family = "windows"))]
 fn test_is_real_root_not_rel_symlinks_not_windows(path: &str) {
     let farm = LinkFarm::new();
@@ -275,6 +276,27 @@ fn test_is_real_root_not_rel_symlinks_not_windows(path: &str) {
         .symlink_rel("A/B/_b1", "b1")
         .symlink_rel("A/B/_a1", "../a1")
         .symlink_rel("A/B/C/_a1", "../../a1");
+
+    check_is_real_root_ok(&farm, path, false);
+}
+
+#[test_case("A/B/__c")]
+#[test_case("A/B/C/_b")]
+#[test_case("__b")]
+#[cfg(not(target_family = "windows"))]
+fn test_is_real_root_not_rel_indirect_symlinks_not_windows(path: &str) {
+    let farm = LinkFarm::new();
+
+    farm.dir("A")
+        .dir("A/B")
+        .dir("A/B/C")
+        .file("A/B/b1")
+        .file("A/B/C/c1")
+        .symlink_rel("_B", "A/B")
+        .symlink_rel("A/B/C/_b", "../../../_B/b1")
+        .symlink_rel("__b", "A/B/C/_b")
+        .symlink_rel("_c", "A/B/C/c1")
+        .symlink_rel("A/B/__c", "../../_c");
 
     check_is_real_root_ok(&farm, path, false);
 }

--- a/tests/path_ext.rs
+++ b/tests/path_ext.rs
@@ -257,7 +257,8 @@ fn test_is_real_root_not_files_directories(path: &str) {
 #[test_case("_B/."; "dot")]
 #[test_case("_B/.."; "dotdot")]
 #[test_case("_x1")]
-fn test_is_real_root_not_rel_symlinks(path: &str) {
+#[cfg(not(target_family = "windows"))]
+fn test_is_real_root_not_rel_symlinks_not_windows(path: &str) {
     let farm = LinkFarm::new();
 
     farm.file("x1")
@@ -281,7 +282,8 @@ fn test_is_real_root_not_rel_symlinks(path: &str) {
 #[test_case("A/B/=b1")]
 #[test_case("A/B/=a1")]
 #[test_case("A/B/=C")]
-fn test_is_real_root_not_abs_symlinks(path: &str) {
+#[cfg(not(target_family = "windows"))]
+fn test_is_real_root_not_abs_symlinks_not_windows(path: &str) {
     let mut farm = LinkFarm::new();
 
     farm.dir("A")

--- a/tests/path_ext.rs
+++ b/tests/path_ext.rs
@@ -227,6 +227,31 @@ fn test_is_real_root_in_root_dir(path: &str) {
     check_is_real_root_in_cwd_ok(root_dir.as_path(), path, true);
 }
 
+#[test]
+fn test_is_real_root_ancestor() {
+    let farm = LinkFarm::new();
+    let farm_depth = farm.depth_below_root();
+    let mut candidate = farm.absolute(".");
+
+    // loop until we have ascended to root
+    for _i in 0..farm_depth {
+        let candidate_path = candidate.as_path();
+        assert!(
+            !candidate_path.is_real_root().unwrap(),
+            "{:?} is not root",
+            candidate_path
+        );
+        candidate = candidate_path.real_parent().unwrap();
+    }
+
+    let candidate_path = candidate.as_path();
+    assert!(
+        candidate_path.is_real_root().unwrap(),
+        "{:?} is root",
+        candidate_path
+    );
+}
+
 #[test_case("x1")]
 #[test_case("A")]
 #[test_case("A/a1")]

--- a/tests/path_ext.rs
+++ b/tests/path_ext.rs
@@ -252,6 +252,25 @@ fn test_is_real_root_ancestor() {
     );
 }
 
+#[test_case("_r1")]
+#[test_case("A/_r2")]
+#[test_case("A/_r1a")]
+#[test_case("A/_r2a")]
+fn test_is_real_root_via_symlinks(path: &str) {
+    let root_dir = root_dir();
+    let root_path = root_dir.as_path();
+    let mut farm = LinkFarm::new();
+
+    farm.dir("A");
+
+    farm.symlink_external("_r1", root_path)
+        .symlink_external("A/_r2", root_path)
+        .symlink_rel("A/_r1a", "../_r1")
+        .symlink_rel("A/_r2a", "_r2");
+
+    check_is_real_root_ok(&farm, path, true);
+}
+
 #[test_case("x1")]
 #[test_case("A")]
 #[test_case("A/a1")]

--- a/tests/path_ext.rs
+++ b/tests/path_ext.rs
@@ -256,7 +256,8 @@ fn test_is_real_root_ancestor() {
 #[test_case("A/_r2")]
 #[test_case("A/_r1a")]
 #[test_case("A/_r2a")]
-fn test_is_real_root_via_symlinks(path: &str) {
+#[cfg(not(target_family = "windows"))]
+fn test_is_real_root_via_symlinks_not_windows(path: &str) {
     let root_dir = root_dir();
     let root_path = root_dir.as_path();
     let mut farm = LinkFarm::new();

--- a/tests/path_ext.rs
+++ b/tests/path_ext.rs
@@ -278,5 +278,24 @@ fn test_is_real_root_not_rel_symlinks(path: &str) {
     check_is_real_root_ok(&farm, path, false);
 }
 
+#[test_case("A/B/=b1")]
+#[test_case("A/B/=a1")]
+#[test_case("A/B/=C")]
+fn test_is_real_root_not_abs_symlinks(path: &str) {
+    let mut farm = LinkFarm::new();
+
+    farm.dir("A")
+        .dir("A/B")
+        .dir("A/C")
+        .file("A/B/b1")
+        .file("A/a1");
+
+    farm.symlink_abs("A/B/=b1", "A/B/b1")
+        .symlink_abs("A/B/=a1", "A/a1")
+        .symlink_abs("A/B/=C", "A/C");
+
+    check_is_real_root_ok(&farm, path, false);
+}
+
 mod helpers;
 use helpers::*;

--- a/tests/path_ext.rs
+++ b/tests/path_ext.rs
@@ -211,7 +211,7 @@ fn test_real_parent_symlink_cycle_look_alikes(path: &str, expected: &str) {
 }
 
 #[test]
-fn test_is_root_root_dir() {
+fn test_is_real_root_root_dir() {
     let path = root_dir();
     let actual = path.as_path().is_real_root().unwrap();
     assert!(actual);
@@ -232,7 +232,7 @@ fn test_is_root_root_dir() {
 #[test_case(""; "empty path")]
 #[test_case("."; "bare dot")]
 #[test_case(".."; "bare dotdot")]
-fn test_is_root_not_files_directories(path: &str) {
+fn test_is_real_root_not_files_directories(path: &str) {
     let farm = LinkFarm::new();
 
     farm.file("x1")
@@ -245,7 +245,7 @@ fn test_is_root_not_files_directories(path: &str) {
         .file("A/.D/d1")
         .file("A/.D/.d1");
 
-    check_is_root_ok(&farm, path, false);
+    check_is_real_root_ok(&farm, path, false);
 }
 
 #[test_case("A/B/_b1")]
@@ -257,7 +257,7 @@ fn test_is_root_not_files_directories(path: &str) {
 #[test_case("_B/."; "dot")]
 #[test_case("_B/.."; "dotdot")]
 #[test_case("_x1")]
-fn test_is_root_not_rel_symlinks(path: &str) {
+fn test_is_real_root_not_rel_symlinks(path: &str) {
     let farm = LinkFarm::new();
 
     farm.file("x1")
@@ -275,7 +275,7 @@ fn test_is_root_not_rel_symlinks(path: &str) {
         .symlink_rel("A/B/_a1", "../a1")
         .symlink_rel("A/B/C/_a1", "../../a1");
 
-    check_is_root_ok(&farm, path, false);
+    check_is_real_root_ok(&farm, path, false);
 }
 
 mod helpers;

--- a/tests/path_ext.rs
+++ b/tests/path_ext.rs
@@ -212,9 +212,19 @@ fn test_real_parent_symlink_cycle_look_alikes(path: &str, expected: &str) {
 
 #[test]
 fn test_is_real_root_root_dir() {
-    let path = root_dir();
-    let actual = path.as_path().is_real_root().unwrap();
+    let root_dir = root_dir();
+
+    let actual = root_dir.as_path().is_real_root().unwrap();
     assert!(actual);
+}
+
+#[test_case(""; "empty")]
+#[test_case("."; "dot")]
+#[test_case(".."; "dotdot")]
+fn test_is_real_root_in_root_dir(path: &str) {
+    let root_dir = root_dir();
+
+    check_is_real_root_in_cwd_ok(root_dir.as_path(), path, true);
 }
 
 #[test_case("x1")]


### PR DESCRIPTION
Because `real_parent` never returns `None`, this provides an alternative convenient way to check whether a path is the root directory.